### PR TITLE
增加启动时不显示通知的开关

### DIFF
--- a/src/STranslate.Model/ConfigModel.cs
+++ b/src/STranslate.Model/ConfigModel.cs
@@ -154,6 +154,11 @@ public class ConfigModel
     public bool IsHideOnStart { get; set; }
 
     /// <summary>
+    ///     启动时不显示通知
+    /// </summary>
+    public bool IsDisableNoticeOnStart { get; set; }
+
+    /// <summary>
     ///     收缩框是否显示复制按钮
     /// </summary>
     public bool ShowCopyOnHeader { get; set; }
@@ -482,6 +487,7 @@ public class ConfigModel
             IsShowHistory = IsShowHistory,
             WordPickingInterval = WordPickingInterval,
             IsHideOnStart = IsHideOnStart,
+            IsDisableNoticeOnStart = IsDisableNoticeOnStart,
             ShowCopyOnHeader = ShowCopyOnHeader,
             IsCaretLast = IsCaretLast,
             ProxyMethod = ProxyMethod,

--- a/src/STranslate/Helper/ConfigHelper.cs
+++ b/src/STranslate/Helper/ConfigHelper.cs
@@ -228,6 +228,7 @@ public class ConfigHelper
         CurrentConfig.IsShowHistory = model.IsShowHistory;
         CurrentConfig.WordPickingInterval = model.WordPickingInterval;
         CurrentConfig.IsHideOnStart = model.IsHideOnStart;
+        CurrentConfig.IsDisableNoticeOnStart = model.IsDisableNoticeOnStart;
         CurrentConfig.ShowCopyOnHeader = model.ShowCopyOnHeader;
         CurrentConfig.IsCaretLast = model.IsCaretLast;
         CurrentConfig.ProxyMethod = model.ProxyMethod;
@@ -763,6 +764,7 @@ public class ConfigHelper
             IsShowHistory = false,
             WordPickingInterval = 100,
             IsHideOnStart = false,
+            IsDisableNoticeOnStart = false,
             ShowCopyOnHeader = false,
             IsCaretLast = false,
             ProxyMethod = ProxyMethodEnum.系统代理,

--- a/src/STranslate/ViewModels/Preference/CommonViewModel.cs
+++ b/src/STranslate/ViewModels/Preference/CommonViewModel.cs
@@ -105,6 +105,11 @@ public partial class CommonViewModel : ObservableObject
     [ObservableProperty] private bool _isHideOnStart = ConfigHelper.CurrentConfig?.IsHideOnStart ?? false;
 
     /// <summary>
+    ///     启动时不显示通知
+    /// </summary>
+    [ObservableProperty] private bool _isDisableNoticeOnStart = ConfigHelper.CurrentConfig?.IsDisableNoticeOnStart ?? false;
+
+    /// <summary>
     ///     是否在关闭鼠标划词后保持最前
     /// </summary>
     [ObservableProperty] private bool _isKeepTopmostAfterMousehook = ConfigHelper.CurrentConfig?.IsKeepTopmostAfterMousehook ?? false;
@@ -491,6 +496,7 @@ public partial class CommonViewModel : ObservableObject
         IsShowConfigureService = ConfigHelper.CurrentConfig?.IsShowConfigureService ?? false;
         WordPickingInterval = ConfigHelper.CurrentConfig?.WordPickingInterval ?? 200;
         IsHideOnStart = ConfigHelper.CurrentConfig?.IsHideOnStart ?? false;
+        IsDisableNoticeOnStart = ConfigHelper.CurrentConfig?.IsDisableNoticeOnStart ?? false;
         ShowCopyOnHeader = ConfigHelper.CurrentConfig?.ShowCopyOnHeader ?? false;
         IsCaretLast = ConfigHelper.CurrentConfig?.IsCaretLast ?? false;
         ProxyMethod = ConfigHelper.CurrentConfig?.ProxyMethod ?? ProxyMethodEnum.系统代理;

--- a/src/STranslate/Views/MainView.xaml.cs
+++ b/src/STranslate/Views/MainView.xaml.cs
@@ -192,14 +192,16 @@ public partial class MainView : Window
             Opacity = 0;
             Visibility = Visibility.Hidden;
 
-            var isAdmin = CommonUtil.IsUserAdministrator();
+            if (!_configHelper.CurrentConfig?.IsDisableNoticeOnStart ?? false) {
+                var isAdmin = CommonUtil.IsUserAdministrator();
 
-            var toolTipFormat = isAdmin ? "STranslate[Admin] {0} started" : "STranslate {0} started";
+                var toolTipFormat = isAdmin ? "STranslate[Admin] {0} started" : "STranslate {0} started";
 
-            var msg = string.Format(toolTipFormat, Constant.AppVersion);
+                var msg = string.Format(toolTipFormat, Constant.AppVersion);
 
-            // 显示信息
-            Singleton<NotifyIconViewModel>.Instance.ShowBalloonTip(msg);
+                // 显示信息
+                Singleton<NotifyIconViewModel>.Instance.ShowBalloonTip(msg);
+            }
         }
         else
         {

--- a/src/STranslate/Views/Preference/CommonPage.xaml
+++ b/src/STranslate/Views/Preference/CommonPage.xaml
@@ -609,6 +609,15 @@
                                 </DockPanel>
 
                                 <DockPanel Margin="20,10">
+                                    <TextBlock HorizontalAlignment="Left" Text="启动时不显示通知" />
+                                    <TextBlock Style="{DynamicResource InfoTextBlock}" ToolTip="启动时不显示通知" />
+                                    <ToggleButton
+                                        Height="26"
+                                        HorizontalAlignment="Right"
+                                        IsChecked="{Binding IsDisableNoticeOnStart}" />
+                                </DockPanel>
+
+                                <DockPanel Margin="20,10">
                                     <TextBlock Text="启动时使用缓存位置" />
                                     <TextBlock Style="{DynamicResource InfoTextBlock}" ToolTip="启动软件时是否使用上次打开位置" />
                                     <ToggleButton


### PR DESCRIPTION
在 `常规设置-显示配置` 中增加 `启动时不显示通知` 开关，控制启动时是否显示系统通知